### PR TITLE
[ITEP-27359] Removal of optional ProjectID in ARM

### DIFF
--- a/app-resource-manager/internal/adm/utils.go
+++ b/app-resource-manager/internal/adm/utils.go
@@ -7,10 +7,11 @@ import (
 	"context"
 	"fmt"
 
+	"time"
+
 	"github.com/open-edge-platform/app-orch-deployment/app-resource-manager/internal/opa"
 	"github.com/open-edge-platform/orch-library/go/pkg/auth"
 	"google.golang.org/grpc/metadata"
-	"time"
 )
 
 func getCtxWithToken(ctx context.Context, vaultAuthClient auth.VaultAuth) (context.Context, error) {

--- a/app-resource-manager/internal/kubernetes/manager.go
+++ b/app-resource-manager/internal/kubernetes/manager.go
@@ -251,9 +251,9 @@ func (m *manager) GetAppEndpointsV2(ctx context.Context, appID string, clusterID
 
 	activeProjectID, err := opa.GetActiveProjectID(ctx)
 	if err != nil {
-		// todo: return error after IAM is ready
-		log.Errorf("Failed to get active project ID: %v", err)
-		activeProjectID = "nil"
+		// Return error since ActiveProjectID is mandatory
+		log.Errorw("Failed to get active project ID", dazl.Error(err))
+		return nil, err
 	}
 
 	serviceEndpoints, err := getServiceAppEndpointsV2(ctx, k8sClient, activeProjectID, appID, appNamespace, clusterID)

--- a/app-resource-manager/internal/kubevirt/manager.go
+++ b/app-resource-manager/internal/kubevirt/manager.go
@@ -211,8 +211,8 @@ func (m *manager) GetVNCAddress(ctx context.Context, appID string, clusterID str
 
 	activeProjectID, err := opa.GetActiveProjectID(ctx)
 	if err != nil {
-		log.Errorf("failed to get active project ID, error: %v", err)
-		activeProjectID = "nil"
+		log.Warnw("ActiveProjectID validation failed", dazl.Error(err))
+		return "", err  // Return error instead of setting to "nil" and continuing
 	}
 
 	if tokenString == "" {

--- a/app-resource-manager/internal/northbound/services/v2/resource/endpoint_service.go
+++ b/app-resource-manager/internal/northbound/services/v2/resource/endpoint_service.go
@@ -25,8 +25,19 @@ func (s *Server) ListAppEndpoints(ctx context.Context, req *resourceapiv2.ListAp
 		return nil, errors.Status(errors.NewInvalid(err.Error())).Err()
 	}
 
+	// Validate ActiveProjectID is present and valid
+	activeProjectID, err := opa.GetActiveProjectID(ctx)
+	if err != nil {
+		log.Warnw("ActiveProjectID validation failed", dazl.Error(err))
+		return nil, errors.Status(errors.NewInvalid(err.Error())).Err()
+	}
+
 	if err := opa.IsAuthorized(ctx, req, s.opaClient); err != nil {
-		log.Warnw("Access denied by OPA rules", dazl.Error(err))
+		log.Warnw("Access denied by OPA rules",
+			dazl.String("AppID", req.AppId),
+			dazl.String("ClusterID", req.ClusterId),
+			dazl.String("ProjectID", activeProjectID),
+			dazl.Error(err))
 		return nil, errors.Status(errors.NewForbidden(err.Error())).Err()
 	}
 

--- a/app-resource-manager/internal/northbound/services/v2/resource/pod_service_test.go
+++ b/app-resource-manager/internal/northbound/services/v2/resource/pod_service_test.go
@@ -4,6 +4,8 @@
 package resource
 
 import (
+	"context"
+
 	resourceapiv2 "github.com/open-edge-platform/app-orch-deployment/app-resource-manager/api/nbi/v2/resource/v2"
 	"github.com/open-edge-platform/orch-library/go/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -54,4 +56,25 @@ func (s *NorthboundTestSuite) TestInvalidPodNameDeletePod() {
 	assert.Nil(s.T(), resp)
 	assert.Error(s.T(), err)
 
+}
+
+// TestDeletePod_MissingActiveProjectID tests the DeletePod API handler behavior when
+// the request context is missing the ActiveProjectID.
+func (s *NorthboundTestSuite) TestDeletePod_MissingActiveProjectID() {
+	// Create context without ActiveProjectID
+	ctxWithoutProjectID := context.Background()
+
+	// Convert to a test client context
+	testCtx := convertToTestContext(ctxWithoutProjectID)
+
+	resp, err := s.podServiceClient.DeletePod(testCtx, &resourceapiv2.DeletePodRequest{
+		ClusterId: testCluster1,
+		Namespace: testNamespace,
+		PodName:   testPodName,
+	})
+
+	assert.Error(s.T(), err)
+	assert.Nil(s.T(), resp)
+	assert.True(s.T(), errors.IsInvalid(errors.FromGRPC(err)))
+	assert.Contains(s.T(), err.Error(), "activeprojectid")
 }

--- a/app-resource-manager/internal/northbound/services/v2/resource/vm_service.go
+++ b/app-resource-manager/internal/northbound/services/v2/resource/vm_service.go
@@ -5,6 +5,7 @@ package resource
 
 import (
 	"context"
+
 	resourceapiv2 "github.com/open-edge-platform/app-orch-deployment/app-resource-manager/api/nbi/v2/resource/v2"
 	"github.com/open-edge-platform/app-orch-deployment/app-resource-manager/internal/opa"
 	"github.com/open-edge-platform/orch-library/go/dazl"
@@ -25,8 +26,18 @@ func (s *Server) GetVNC(ctx context.Context, req *resourceapiv2.GetVNCRequest) (
 		return nil, errors.Status(errors.NewInvalid(err.Error())).Err()
 	}
 
+	// Validate ActiveProjectID is present and valid
+	activeProjectID, err := opa.GetActiveProjectID(ctx)
+	if err != nil {
+		log.Warnw("ActiveProjectID validation failed", dazl.Error(err))
+		return nil, errors.Status(errors.NewInvalid(err.Error())).Err()
+	}
+
 	if err := opa.IsAuthorized(ctx, req, s.opaClient); err != nil {
-		log.Warnw("Access denied by OPA rules", dazl.Error(err))
+		log.Warnw("Access denied by OPA rules",
+			dazl.String("AppID", req.AppId),
+			dazl.String("ProjectID", activeProjectID),
+			dazl.Error(err))
 		return nil, errors.Status(errors.NewForbidden(err.Error())).Err()
 	}
 
@@ -55,8 +66,18 @@ func (s *Server) RestartVirtualMachine(ctx context.Context, req *resourceapiv2.R
 		return nil, errors.Status(errors.NewInvalid(err.Error())).Err()
 	}
 
+	// Validate ActiveProjectID is present and valid
+	activeProjectID, err := opa.GetActiveProjectID(ctx)
+	if err != nil {
+		log.Warnw("ActiveProjectID validation failed", dazl.Error(err))
+		return nil, errors.Status(errors.NewInvalid(err.Error())).Err()
+	}
+
 	if err := opa.IsAuthorized(ctx, req, s.opaClient); err != nil {
-		log.Warnw("Access denied by OPA rules", dazl.Error(err))
+		log.Warnw("Access denied by OPA rules",
+			dazl.String("AppID", req.AppId),
+			dazl.String("ProjectID", activeProjectID),
+			dazl.Error(err))
 		return nil, errors.Status(errors.NewForbidden(err.Error())).Err()
 	}
 
@@ -83,8 +104,18 @@ func (s *Server) StartVirtualMachine(ctx context.Context, req *resourceapiv2.Sta
 		return nil, errors.Status(errors.NewInvalid(err.Error())).Err()
 	}
 
+	// Validate ActiveProjectID is present and valid
+	activeProjectID, err := opa.GetActiveProjectID(ctx)
+	if err != nil {
+		log.Warnw("ActiveProjectID validation failed", dazl.Error(err))
+		return nil, errors.Status(errors.NewInvalid(err.Error())).Err()
+	}
+
 	if err := opa.IsAuthorized(ctx, req, s.opaClient); err != nil {
-		log.Warnw("Access denied by OPA rules", dazl.Error(err))
+		log.Warnw("Access denied by OPA rules",
+			dazl.String("AppID", req.AppId),
+			dazl.String("ProjectID", activeProjectID),
+			dazl.Error(err))
 		return nil, errors.Status(errors.NewForbidden(err.Error())).Err()
 	}
 
@@ -113,8 +144,18 @@ func (s *Server) StopVirtualMachine(ctx context.Context, req *resourceapiv2.Stop
 		return nil, errors.Status(errors.NewInvalid(err.Error())).Err()
 	}
 
+	// Validate ActiveProjectID is present and valid
+	activeProjectID, err := opa.GetActiveProjectID(ctx)
+	if err != nil {
+		log.Warnw("ActiveProjectID validation failed", dazl.Error(err))
+		return nil, errors.Status(errors.NewInvalid(err.Error())).Err()
+	}
+
 	if err := opa.IsAuthorized(ctx, req, s.opaClient); err != nil {
-		log.Warnw("Access denied by OPA rules", dazl.Error(err))
+		log.Warnw("Access denied by OPA rules",
+			dazl.String("AppID", req.AppId),
+			dazl.String("ProjectID", activeProjectID),
+			dazl.Error(err))
 		return nil, errors.Status(errors.NewForbidden(err.Error())).Err()
 	}
 

--- a/app-resource-manager/internal/northbound/services/v2/resource/vm_service_test.go
+++ b/app-resource-manager/internal/northbound/services/v2/resource/vm_service_test.go
@@ -4,6 +4,8 @@
 package resource
 
 import (
+	"context"
+
 	resourceapiv2 "github.com/open-edge-platform/app-orch-deployment/app-resource-manager/api/nbi/v2/resource/v2"
 	"github.com/open-edge-platform/orch-library/go/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -204,4 +206,89 @@ func (s *NorthboundTestSuite) TestRestartVirtualMachineError() {
 	})
 
 	assert.Error(s.T(), err)
+}
+
+// Test MissingActiveProjectID for GetVNC, RestartVirtualMachine, StartVirtualMachine,
+// StopVirtualMachine functions verifies that the methods returns an appropriate error
+// when the request context does not contain an ActiveProjectID.
+func (s *NorthboundTestSuite) TestGetVNC_MissingActiveProjectID() {
+	// Create context without ActiveProjectID
+	ctxWithoutProjectID := context.Background()
+
+	// Convert to a test client context
+	testCtx := convertToTestContext(ctxWithoutProjectID)
+
+	resp, err := s.vmServiceClient.GetVNC(testCtx, &resourceapiv2.GetVNCRequest{
+		ClusterId:        testCluster1,
+		AppId:            testApp1,
+		VirtualMachineId: testVM1,
+	})
+
+	assert.Error(s.T(), err)
+	assert.Nil(s.T(), resp)
+	// Verify it's the right error type
+	assert.True(s.T(), errors.IsInvalid(errors.FromGRPC(err)))
+	// Verify error message
+	assert.Contains(s.T(), err.Error(), "activeprojectid")
+}
+
+func (s *NorthboundTestSuite) TestStartVirtualMachine_MissingActiveProjectID() {
+	// Create context without ActiveProjectID
+	ctxWithoutProjectID := context.Background()
+
+	// Convert to a test client context
+	testCtx := convertToTestContext(ctxWithoutProjectID)
+
+	resp, err := s.vmServiceClient.StartVirtualMachine(testCtx, &resourceapiv2.StartVirtualMachineRequest{
+		ClusterId:        testCluster1,
+		AppId:            testApp1,
+		VirtualMachineId: testVM1,
+	})
+
+	assert.Error(s.T(), err)
+	assert.Nil(s.T(), resp)
+	assert.True(s.T(), errors.IsInvalid(errors.FromGRPC(err)))
+	assert.Contains(s.T(), err.Error(), "activeprojectid")
+}
+
+func (s *NorthboundTestSuite) TestStopVirtualMachine_MissingActiveProjectID() {
+	// Create context without ActiveProjectID
+	ctxWithoutProjectID := context.Background()
+
+	// Convert to a test client context
+	testCtx := convertToTestContext(ctxWithoutProjectID)
+
+	resp, err := s.vmServiceClient.StopVirtualMachine(testCtx, &resourceapiv2.StopVirtualMachineRequest{
+		ClusterId:        testCluster1,
+		AppId:            testApp1,
+		VirtualMachineId: testVM1,
+	})
+
+	assert.Error(s.T(), err)
+	assert.Nil(s.T(), resp)
+	assert.True(s.T(), errors.IsInvalid(errors.FromGRPC(err)))
+	assert.Contains(s.T(), err.Error(), "activeprojectid")
+}
+
+func (s *NorthboundTestSuite) TestRestartVirtualMachine_MissingActiveProjectID() {
+	// Create context without ActiveProjectID
+	ctxWithoutProjectID := context.Background()
+
+	// Convert to a test client context
+	testCtx := convertToTestContext(ctxWithoutProjectID)
+
+	resp, err := s.vmServiceClient.RestartVirtualMachine(testCtx, &resourceapiv2.RestartVirtualMachineRequest{
+		ClusterId:        testCluster1,
+		AppId:            testApp1,
+		VirtualMachineId: testVM1,
+	})
+
+	assert.Error(s.T(), err)
+	assert.Nil(s.T(), resp)
+	assert.True(s.T(), errors.IsInvalid(errors.FromGRPC(err)))
+	assert.Contains(s.T(), err.Error(), "activeprojectid")
+}
+
+func convertToTestContext(ctx context.Context) context.Context {
+	return ctx
 }

--- a/app-resource-manager/internal/opa/opa.go
+++ b/app-resource-manager/internal/opa/opa.go
@@ -8,14 +8,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/open-edge-platform/orch-library/go/dazl"
-	"github.com/open-edge-platform/orch-library/go/pkg/errors"
-	"github.com/open-edge-platform/orch-library/go/pkg/openpolicyagent"
-	"google.golang.org/grpc/metadata"
 	"os"
 	"reflect"
 	"strconv"
 	"strings"
+
+	"github.com/open-edge-platform/orch-library/go/dazl"
+	"github.com/open-edge-platform/orch-library/go/pkg/errors"
+	"github.com/open-edge-platform/orch-library/go/pkg/openpolicyagent"
+	"google.golang.org/grpc/metadata"
 )
 
 const (
@@ -72,9 +73,9 @@ func GetActiveProjectID(ctx context.Context) (string, error) {
 		return "", errors.NewInvalid("multiple ActiveProjectIDs are set - it should be one")
 	}
 
-	// TODO: will be removed once fully MT is integrated, as activeProjectID is mandatory field for the future but not now
+	// Enforce that activeProjectID is mandatory
 	if len(activeProjectIDs) == 0 {
-		return "", nil
+		return "", errors.NewInvalid("activeprojectid is not set")
 	}
 
 	return activeProjectIDs[0], nil


### PR DESCRIPTION
## Description

Remove ProjectID set as optional from ARM. Enforce everywhere to check ProjectID and return error if no active project ID is found.

## Changes

List the changes you have made.

## Additional Information

Include any additional information, such as how to test your changes.

## Checklist

- [ ] Tests passed
- [ ] Documentation updated
