### PR TITLE
crypto x/509 secruity fix

### DIFF
--- a/app-deployment-manager/Dockerfile
+++ b/app-deployment-manager/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Build the manager binary
-FROM golang:1.24.2@sha256:d9db32125db0c3a680cfb7a1afcaefb89c898a075ec148fdc2f0f646cc2ed509 AS builder
+FROM golang:1.24.4@sha256:20a022e5112a144aa7b7aeb3f22ebf2cdaefcc4aac0d64e8deeee8cdc18b9c0f AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ENV CGO_ENABLED=0

--- a/app-deployment-manager/build/Dockerfile.gateway
+++ b/app-deployment-manager/build/Dockerfile.gateway
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM golang:1.24.2@sha256:d9db32125db0c3a680cfb7a1afcaefb89c898a075ec148fdc2f0f646cc2ed509 AS build
+FROM golang:1.24.4@sha256:20a022e5112a144aa7b7aeb3f22ebf2cdaefcc4aac0d64e8deeee8cdc18b9c0f AS build
 
 ENV APP_ROOT=$GOPATH/src/github.com/open-edge-platform/app-orch-deployment/app-deployment-manager
 ENV CGO_ENABLED=0

--- a/app-deployment-manager/deployment/charts/app-deployment-crd/Chart.yaml
+++ b/app-deployment-manager/deployment/charts/app-deployment-crd/Chart.yaml
@@ -6,8 +6,8 @@ apiVersion: v2
 description: App Deployment CustomResourceDefinitions
 name: app-deployment-crd
 # Correct version will be added by "make helm-package" from VERSION
-version: 2.4.21
+version: 2.4.22-dev
 annotations:
-  revision: "0779b30"
-  created: "2025-07-23T13:22:03Z"
-appVersion: 2.4.21
+  revision: "de82c80"
+  created: "2025-08-04T09:30:57Z"
+appVersion: 2.4.22-dev-de82c80

--- a/app-deployment-manager/deployment/charts/app-deployment-manager/Chart.yaml
+++ b/app-deployment-manager/deployment/charts/app-deployment-manager/Chart.yaml
@@ -6,8 +6,8 @@ apiVersion: v2
 description: App Deployment Manager
 name: app-deployment-manager
 # Correct version will be added by "make helm-package" from VERSION
-version: 2.4.21
+version: 2.4.22-dev
 annotations:
-  revision: "0779b30"
-  created: "2025-07-23T13:22:03Z"
-appVersion: 2.4.21
+  revision: "de82c80"
+  created: "2025-08-04T09:30:57Z"
+appVersion: 2.4.22-dev-de82c80

--- a/app-deployment-manager/deployment/charts/app-deployment-manager/values.yaml
+++ b/app-deployment-manager/deployment/charts/app-deployment-manager/values.yaml
@@ -88,7 +88,7 @@ adm:
   gitProvider: gitea
   gitUser:
   gitPassword:
-  gitServer: https://gitea.kind.internal
+  gitServer: https://gitea.orch-10-114-181-148.espdqa.infra-host.com
   gitProxy: ""
   gitUseCaCert: true
   gitCaCertSecret: gitea-ca-cert

--- a/app-deployment-manager/go.mod
+++ b/app-deployment-manager/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/open-edge-platform/app-orch-deployment/app-deployment-manager
 
-go 1.24.0
+go 1.24.4
 
 replace (
 	github.com/open-edge-platform/app-orch-deployment/app-deployment-manager/api/nbi/v2 => ./api/nbi/v2

--- a/app-deployment-manager/go.sum
+++ b/app-deployment-manager/go.sum
@@ -59,8 +59,6 @@ github.com/chenzhuoyu/iasm v0.9.0/go.mod h1:Xjy2NpN3h7aUqeqM+woSuuvxmIe6+DDsiNLI
 github.com/chenzhuoyu/iasm v0.9.1 h1:tUHQJXo3NhBqw6s33wkGn9SP3bvrWLdlVIJ3hQBL7P0=
 github.com/chenzhuoyu/iasm v0.9.1/go.mod h1:Xjy2NpN3h7aUqeqM+woSuuvxmIe6+DDsiNLIrkAmYog=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
-github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
 github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=
 github.com/cloudflare/circl v1.6.1/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=


### PR DESCRIPTION
## Description

CVE-2025-22874 was caused by using Go 1.24.2 in Docker containers while the source code required Go 1.24.4 (the secure version that fixes the crypto/x509 vulnerability).

## Changes

List the changes you have made.

## Additional Information

Include any additional information, such as how to test your changes.

## Checklist

- [ ] Tests passed
- [ ] Documentation updated
