### PR TITLE
Enable post-merge security scans for tag creation

### DIFF
--- a/.github/workflows/post-merge-adm-nbi.yaml
+++ b/.github/workflows/post-merge-adm-nbi.yaml
@@ -11,6 +11,8 @@ on:
       - release-*
     paths:
       - 'app-deployment-manager/api/nbi/**'
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/post-merge-adm.yaml
+++ b/.github/workflows/post-merge-adm.yaml
@@ -11,6 +11,8 @@ on:
       - release-*
     paths:
       - 'app-deployment-manager/**'
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/post-merge-arm.yaml
+++ b/.github/workflows/post-merge-arm.yaml
@@ -11,6 +11,8 @@ on:
       - release-*
     paths:
       - 'app-resource-manager/**'
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/post-merge-asp.yaml
+++ b/.github/workflows/post-merge-asp.yaml
@@ -11,6 +11,8 @@ on:
       - release-*
     paths:
       - 'app-service-proxy/**'
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request updates several GitHub Actions workflow trigger configurations to allow workflows to be triggered by any tag. This change makes it possible to run the relevant post-merge workflows not only on branch pushes but also on tag pushes, improving release automation and flexibility.

**Workflow trigger updates:**

* **Enable tag-based triggers for post-merge workflows:**
  - [`.github/workflows/post-merge-adm-nbi.yaml`](diffhunk://#diff-26fa61ea2e041130ee1a0aed36d6d56c02500235d044dad2d37c8a5fe7cbd1a0R14-R15): Added support for triggering the workflow on any tag push.
  - [`.github/workflows/post-merge-adm.yaml`](diffhunk://#diff-5e97da1af1dfe0c6c76ffcc3dd18e3e52a6245e7b1e64a90bd4c3cecc406a08aR14-R15): Added support for triggering the workflow on any tag push.
  - [`.github/workflows/post-merge-arm.yaml`](diffhunk://#diff-e19c347323cff48a0d8a79d923db769efcd00b89a828dff24fbf46cee9289d3bR14-R15): Added support for triggering the workflow on any tag push.
  - [`.github/workflows/post-merge-asp.yaml`](diffhunk://#diff-c5a7cd953ae86ac0ef028cf98f0db4b64eba0c19fa448a0999e8638286761eecR14-R15): Added support for triggering the workflow on any tag push.